### PR TITLE
Fix repo url ending with a '/'

### DIFF
--- a/git_pull_request/__init__.py
+++ b/git_pull_request/__init__.py
@@ -124,7 +124,7 @@ def get_github_hostname_user_repo_from_url(url):
         if "@" in host:
             username, sep, host = host.partition("@")
     else:
-        path = parsed.path[1:]
+        path = parsed.path[1:].rstrip('/')
         host = parsed.netloc
     user, repo = path.split("/", 1)
     return host, user, repo[:-4] if repo.endswith('.git') else repo


### PR DESCRIPTION
When doing "git clone https://github.com/user/repo/",
then git pull-request fails with "404 {'message': 'Not Found'}"
because the url used doesn't remove trailing slash.

This change prevents this issue by rstriping any '/' in the repo url.