### PR TITLE
Handle github exceptions with no messages

### DIFF
--- a/git_pull_request/__init__.py
+++ b/git_pull_request/__init__.py
@@ -459,8 +459,8 @@ def fork_and_push_pull_request(g, repo_to_fork, rebase, target_remote,
 
 def _format_github_exception(action, exc):
     url = exc.data.get("documentation_url", "GitHub documentation")
-    errors_msg = "\n".join(map(operator.itemgetter("message"),
-                               exc.data.get("errors", [])))
+    errors_msg = "\n".join(error.get("message", "")
+                           for error in exc.data.get("errors", []))
     return (
         "Unable to %s: %s (%s)\n"
         "%s\n"

--- a/git_pull_request/tests/test_gpr.py
+++ b/git_pull_request/tests/test_gpr.py
@@ -209,6 +209,24 @@ class TestExceptionFormatting(unittest.TestCase):
             "for more information.",
             gpr._format_github_exception("create pull request", e))
 
+    def test_no_message(self):
+        e = github.GithubException(422, {
+            'message': 'Validation Failed',
+            'documentation_url':
+            'https://developer.github.com/v3/pulls/#create-a-pull-request',
+            'errors': [{
+                'resource': 'PullRequest',
+                'field': 'head',
+                'code': 'invalid'}
+            ]}
+        )
+        self.assertEqual(
+            "Unable to create pull request: Validation Failed (422)\n\n"
+            "Check "
+            "https://developer.github.com/v3/pulls/#create-a-pull-request "
+            "for more information.",
+            gpr._format_github_exception("create pull request", e))
+
 
 class TestGithubHostnameUserRepoFromUrl(unittest.TestCase):
     def test_git_clone_url(self):


### PR DESCRIPTION
Sometimes the error returned doesn't have a message field, and the
exception formatter doesn't handle the case. This fixes the behavior.