### PR TITLE
Close fd returned by mkstemp

### DIFF
--- a/git_pull_request/__init__.py
+++ b/git_pull_request/__init__.py
@@ -308,6 +308,7 @@ def find_pull_request_template():
 
 def get_pr_template_message(template):
     fd, bodyfilename = tempfile.mkstemp()
+    os.close(fd)
     shutil.copy(template, bodyfilename)
     content = edit_file_get_content_and_remove(bodyfilename)
 
@@ -316,6 +317,7 @@ def get_pr_template_message(template):
 
 def edit_title_and_message(title, message):
     fd, bodyfilename = tempfile.mkstemp()
+    os.close(fd)
     with open(bodyfilename, "w") as body:
         body.write(title + "\n\n")
         body.write(message + "\n")


### PR DESCRIPTION
If the fd returned by mkstemps is kept opened while the os.system call is
happening, sometimes the application trying to write the file is going to fail.
This fixes it by closing the returned fd before passing the file around. It's
slightly less secure but I think in this case it's fine.